### PR TITLE
Use git's pushURL (requires git >= 1.6.4)

### DIFF
--- a/git_trac/app.py
+++ b/git_trac/app.py
@@ -392,7 +392,7 @@ class Application(object):
         diff = self.repo.review_diff(remote)
         print(diff)
 
-    def add_remote(self, readonly):
+    def add_remote(self):
         """
         Add the "trac" remote if necessary
         
@@ -403,11 +403,10 @@ class Application(object):
         """
         REPO_RW = 'git@trac.sagemath.org:sage.git'
         REPO_RO = 'git://trac.sagemath.org/sage.git'
-        repo = REPO_RO if readonly else REPO_RW
         remotes = self.git.remote().split()
         if 'trac' in remotes:
             cmd = 'set-url'
         else:
             cmd = 'add'
-        self.git.remote(cmd, 'trac', repo)
-        
+        self.git.remote(cmd, 'trac', REPO_RO)
+        self.git.remote('set-url', '--push', 'trac', REPO_RW)

--- a/git_trac/cmdline.py
+++ b/git_trac/cmdline.py
@@ -135,8 +135,6 @@ def launch():
                             default=False, help='One line per commit')
 
     parser_config = subparsers.add_parser('config', help='Configure git-trac')
-    parser_config.add_argument('--readonly', dest='readonly', action='store_true',
-                               help='Read only remote (does not require SSH keys)', default=False)
     parser_config.add_argument('--user', dest='trac_user', 
                                help='Trac username', default=None)
     parser_config.add_argument('--pass', dest='trac_pass', 
@@ -193,7 +191,7 @@ def launch():
             parser_search.print_help()
             raise
     elif args.subcommand == 'config':
-        app.add_remote(args.readonly)
+        app.add_remote()
         if args.trac_user is not None:
             app.save_trac_username(args.trac_user)
         if args.trac_pass is not None:


### PR DESCRIPTION
This way the readonly option is no longer required.

Fetching always happens through the anonymous git://-url. Pushing requires ssh.

Since Debian squeeze has git 1.7.2 and Ubuntu lucid has git 1.7.0, I think
git>=1.6.4 should be fine.
