### PR TITLE
Possible update for readme for Mac situation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Alternatively you can just symlink ``git-trac`` to anywhere in your path:
     $ cd git-trac-command
     $ ln -s `pwd`/git-trac ~/bin/
 
+On a Mac, which may not have a default in the home directory for commands,
+it may be easier to add this to your ``.profile``: 
+
+    $ git clone https://github.com/sagemath/git-trac-command.git
+    $ cd git-trac-command
+    $ pico/vim/emacs $HOME/.profile
+    <add a line like "export PATH=$PATH:$HOME/Downloads/git-trac-command/bin">
 
 Usage
 -----


### PR DESCRIPTION
I prefer to add things to my path than create a `$HOME/bin` directory that Mac doesn't really 'do', at least by default.  This workflow worked for me.  If you think this stinks, it would be nice to have something mentioning the profile or bashrc, which however on Mac doesn't seem to have the same role as on Linux.
