### PR TITLE
Fixdeprecation

### DIFF
--- a/git_trac/cmdline.py
+++ b/git_trac/cmdline.py
@@ -45,7 +45,7 @@ def show_cheat_sheet():
 
 
 def debug_shell(app, parser):
-    from IPython.frontend.terminal.ipapp import TerminalIPythonApp
+    from IPython.terminal.ipapp import TerminalIPythonApp
     ip = TerminalIPythonApp.instance()
     ip.initialize(argv=[])
     ip.shell.user_global_ns['app'] = app

--- a/git_trac/releasemgr/cmdline.py
+++ b/git_trac/releasemgr/cmdline.py
@@ -31,7 +31,7 @@ from ..logger import logger
 
 
 def debug_shell(app):
-    from IPython.frontend.terminal.ipapp import TerminalIPythonApp
+    from IPython.terminal.ipapp import TerminalIPythonApp
     ip = TerminalIPythonApp.instance()
     ip.initialize(argv=[])
     ip.shell.user_global_ns['app'] = app


### PR DESCRIPTION
Removed references to frontend

This should prevent warnings like
>>> from IPython.frontend.terminal.ipapp import TerminalIPythonApp
... UserWarning: The top-level `frontend` package has been deprecated. All its subpackages have been moved to the top `IPython` level.
  warn("The top-level `frontend` package has been deprecated. "