### PR TITLE
No warning raised for 'git trac config' when no account is configured.

### DIFF
--- a/git_trac/app.py
+++ b/git_trac/app.py
@@ -321,6 +321,7 @@ class Application(object):
             Username: trac_user
             Password: trac_pass
         """
+        from config import AuthenticationError
         c = self.config
         print('Trac xmlrpc URL:')
         print('    {0} (anonymous)'.format(self.trac.url_anonymous))
@@ -329,7 +330,7 @@ class Application(object):
         try:
             c.username
             anonymous_only = False
-        except ValueError:
+        except AuthenticationError:
             anonymous_only = True
 
         if anonymous_only:

--- a/git_trac/app.py
+++ b/git_trac/app.py
@@ -306,7 +306,7 @@ class Application(object):
     def save_trac_password(self, password):
         self.config.password = password
         print('Saved trac password.')
-        
+
     def print_config(self, ssh_keys=True):
         """
         Print configuration information
@@ -326,12 +326,22 @@ class Application(object):
         print('    {0} (anonymous)'.format(self.trac.url_anonymous))
         print('    {0} (authenticated)'.format(self.trac.url_authenticated))
         print('    realm {0}'.format(c.server_realm))
-        print('Username: {0}'.format(c.username))
-        print('Password: {0}'.format(c.password))
-        if ssh_keys:
-            print('Retrieving SSH keys...')
-            for key in self.trac.get_ssh_fingerprints():
-                print('    {0}'.format(key))
+        try:
+            c.username
+            anonymous_only = False
+        except ValueError:
+            anonymous_only = True
+
+        if anonymous_only:
+            print('Anonymous (read) access only. To configure an account, use:')
+            print('    git trac config --user=<name> --password=<password>')
+        else:
+            print('Username: {0}'.format(c.username))
+            print('Password: {0}'.format(c.password))
+            if ssh_keys:
+                print('Retrieving SSH keys...')
+                for key in self.trac.get_ssh_fingerprints():
+                    print('    {0}'.format(key))
 
     def print_ticket(self, ticket_number):
         """
@@ -438,7 +448,7 @@ class Application(object):
             print('Commit has not been merged by the release manager into your current branch.')
             return
         self.git.echo.show(merge.sha1, '--color=always')
-        
+
     def review_diff(self, ticket_number):
         remote = self.trac.remote_branch(ticket_number)
         diff = self.repo.review_diff(remote)
@@ -446,12 +456,7 @@ class Application(object):
 
     def add_remote(self):
         """
-        Add the "trac" remote if necessary
-        
-        INPUT:
-
-        - ``readonly`` -- boolean. Whether to use ssh or http
-        transport.
+        Add the "trac" remotes (RW+RO) if necessary
         """
         REPO_RW = 'git@trac.sagemath.org:sage.git'
         REPO_RO = 'git://trac.sagemath.org/sage.git'

--- a/git_trac/config.py
+++ b/git_trac/config.py
@@ -73,7 +73,7 @@ class Config(object):
         try:
             return self._load('trac.username')
         except GitError:
-            raise SystemExit('Use "git trac config --user=<name>"'
+            raise ValueError('Use "git trac config --user=<name>"'
                              ' to set your trac username')
 
     @username.setter
@@ -89,7 +89,7 @@ class Config(object):
         try:
             return self._load('trac.password')
         except GitError:
-            raise SystemExit('Use "git trac config --pass=<secret>"'
+            raise ValueError('Use "git trac config --pass=<secret>"'
                              ' to set your trac password')
 
     @password.setter

--- a/git_trac/config.py
+++ b/git_trac/config.py
@@ -73,8 +73,8 @@ class Config(object):
         try:
             return self._load('trac.username')
         except GitError:
-            raise ValueError('Use "git trac config --user=<name>"'
-                             ' to set your trac username')
+            raise AuthenticationError('Use "git trac config --user=<name>"'
+                                      ' to set your trac username')
 
     @username.setter
     def username(self, value):
@@ -89,9 +89,12 @@ class Config(object):
         try:
             return self._load('trac.password')
         except GitError:
-            raise ValueError('Use "git trac config --pass=<secret>"'
-                             ' to set your trac password')
+            raise AuthenticationError('Use "git trac config --pass=<secret>"'
+                                      ' to set your trac password')
 
     @password.setter
     def password(self, value):
         self._save('trac.password', value)
+
+class AuthenticationError(Exception):
+    pass


### PR DESCRIPTION
With those changes, 'git trac config' does not exit unexpectedly: not having configured a username is fine for somebody who only wants read-only access.