### PR TITLE
Add new command: git trac old.

### DIFF
--- a/git_trac/cmdline.py
+++ b/git_trac/cmdline.py
@@ -125,6 +125,13 @@ def make_parser():
     parser_checkout.add_argument('ticket_or_branch', type=TicketOrBranch, 
                                  help='Ticket number or remote branch name')
 
+    parser_old = subparsers.add_parser('old', help='Download branch, merge into develop')
+    parser_old.add_argument('-b', '--branch', dest='branch_name',
+                            help='Local branch name',
+                            default=None)
+    parser_old.add_argument('ticket_or_branch', type=TicketOrBranch,
+                            help='Ticket number or remote branch name')
+
     parser_search = subparsers.add_parser('search', help='Search trac')
     parser_search.add_argument('--branch', dest='branch_name', 
                                help='Remote git branch name (default: local branch)', 
@@ -213,6 +220,8 @@ def launch():
         app.create(args.summary, args.branch_name)
     elif args.subcommand == 'checkout':
         app.checkout(args.ticket_or_branch, args.branch_name)
+    elif args.subcommand == 'old':
+        app.old(args.ticket_or_branch, args.branch_name)
     elif args.subcommand == 'fetch':
         app.fetch(args.ticket_or_branch)
     elif args.subcommand == 'pull':


### PR DESCRIPTION
As discussed on [this sage-devel thread](https://groups.google.com/forum/#!topic/sage-devel/58aRZzTMSrA), it is frustrating to checkout an old branch and have it touch most of the files in Sage's source tree, since this essentially forces a total rebuild.

This ticket implements a simple fix: add a new command that instead checks out develop first, then pulls in changes from the old branch.