### PR TITLE
Allow enable.sh to work with zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ change is made:
     $ source git-trac-command/enable.sh
     Prepending the git-trac command to your search PATH
     
-**Note for `zsh` users:** `enable.sh` requires bash. Use one of the other options described below. 
-
 To permanently install the code from this repo, clone it and run
 ``setup.py``:
 

--- a/enable.sh
+++ b/enable.sh
@@ -7,19 +7,7 @@
 #     [user@localhost]$ source enable.sh
 #
 
-if [ -z $BASH_VERSION ]
-then
-    echo "This script only works if you use bash, aborting."
-    exit 1
-fi
-
-if [ ${BASH_VERSINFO[0]} -le 2 ]
-then
-    echo 'Your bash version is too old.'
-    exit 1
-fi
-
-if [ "${BASH_SOURCE[0]}" == "${0}" ]
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]
 then
     echo "You are trying to call this script directly, which is not"
     echo "possible. You must source this script instead:" 
@@ -29,13 +17,32 @@ then
     exit 1
 fi
 
-GIT_TRAC_DIR=`cd $(dirname -- $BASH_SOURCE)/bin && pwd -P`
-GIT_TRAC_CMD="$GIT_TRAC_DIR/git-trac"
+function set_path_git_trac {
+    GIT_TRAC_CMD="$GIT_TRAC_DIR/git-trac"
 
-if [ "$(command -v git-trac)" == "$GIT_TRAC_CMD" ]
-then
-    echo "The git-trac command is already in your search PATH"
+    if [[ "$(command -v git-trac)" == "$GIT_TRAC_CMD" ]]
+    then
+        echo "The git-trac command is already in your search PATH"
+    else
+        echo "Prepending the git-trac command to your search PATH"
+        export PATH="$GIT_TRAC_DIR":$PATH
+    fi
+}
+
+if [[ -n $BASH_VERSION ]]; then
+    # Assume bash
+    if [[ ${BASH_VERSINFO[0]} -le 2 ]]
+    then
+        echo 'Your bash version is too old.'
+    fi
+    GIT_TRAC_DIR=`cd $(dirname -- $BASH_SOURCE)/bin && pwd -P`
+    set_path_git_trac
+elif [[ -n $ZSH_VERSION ]]; then
+    # Assume zsh
+    GIT_TRAC_DIR=`cd $(dirname -- ${(%):-%x})/bin && pwd -P`
+    set_path_git_trac
 else
-    echo "Prepending the git-trac command to your search PATH"
-    export PATH="$GIT_TRAC_DIR":$PATH
-fi
+    echo "This script only works if you use bash or zsh, aborting."
+fi 
+
+unset set_path_git_trac


### PR DESCRIPTION
This PR is to address https://github.com/sagemath/git-trac-command/issues/28 . I'm inexperienced with shell scripts so be very skeptical of my PR! But I tried my best.

1. I changed the single brackets to double brackets so it works with `zsh`.

2. If the script detects that this is being sourced from `zsh`, we use `${(%):-%x}` instead of `$BASH_SOURCE` (stolen from here: https://stackoverflow.com/a/28336473)

3. I did some refactoring to remove some `exit 1`. This is because, when being sourced, this script would use to print the error message and then exit immediately so the user would have no idea what went wrong! 


