### PR TITLE
Actually install the cheat sheet when using setup.py

### DIFF
--- a/git_trac/cmdline.py
+++ b/git_trac/cmdline.py
@@ -44,8 +44,27 @@ def xdg_open(uri):
 
 
 def show_cheat_sheet():
+    # case where `git-trac` was just symbolically linked
     root_dir = os.path.dirname(os.path.dirname(__file__))
     cheat_sheet = os.path.join(root_dir, 'doc', 'git-cheat-sheet.pdf')
+    # case of `python setup.py install --user`
+    if not os.path.exists(cheat_sheet):
+        root_dir = __import__('site').USER_BASE
+        cheat_sheet = os.path.join(root_dir,
+                                   'share',
+                                   'git-trac-command',
+                                   'git-cheat-sheet.pdf')
+    # case of `python setup.py install`
+    if not os.path.exists(cheat_sheet):
+        root_dir = sys.prefix
+        cheat_sheet = os.path.join(root_dir,
+                                   'share',
+                                   'git-trac-command',
+                                   'git-cheat-sheet.pdf')
+    # go to internet if not found
+    if not os.path.exists(cheat_sheet):
+        cheat_sheet = "http://github.com/sagemath/git-trac-command/raw/master/doc/git-cheat-sheet.pdf"
+        print('Cheat sheet not found locally. Trying the internet.')
     xdg_open(cheat_sheet)
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author='Volker Braun',
     author_email='vbraun.name@gmail.com',
     packages=['git_trac'],
+    data_files=[('share/git-trac-command', ['doc/git-cheat-sheet.pdf'])],
     scripts=['git-trac'],
     version='1.0',
     url='https://github.com/sagemath/git-trac-command',


### PR DESCRIPTION
This PR is to address issue https://github.com/sagemath/git-trac-command/issues/14.

`setup.py` will now actually install the cheat sheet. Running `git trac cheat-sheet` will try to find the cheat sheet locally. If that fails, use the internet. 