### PR TITLE
Switching from the insecure git:// protocol to git over ssh and https://

### DIFF
--- a/doc/git-cheat-sheet.tex
+++ b/doc/git-cheat-sheet.tex
@@ -112,7 +112,7 @@ This data ends up in commits, so do it now before you forget!
 \subsection{Get the Sage Source Code}
 
 \begin{Verbatim}
-  git clone git://github.com/sagemath/sage.git
+  git clone https://github.com/sagemath/sage.git
 \end{Verbatim}
 
 

--- a/enable.sh
+++ b/enable.sh
@@ -39,3 +39,9 @@ else
     echo "Prepending the git-trac command to your search PATH"
     export PATH="$GIT_TRAC_DIR":$PATH
 fi
+
+if [ ! -d "$HOME/.ssh" ]; then
+	mkdir "$HOME/.ssh"
+fi
+
+ssh-keygen -F trac.sagemath.org > /dev/null || echo "trac.sagemath.org ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBG+/AO490umZWuczUgClP4BgFm5XR9I43z4kf9f+pu8Uj6UvH/7Pz1oBkJ71xET+xTmecBHB2c9OwlgPjB70AB8= This was added by git-trac-command/enable.sh" >> "$HOME/.ssh/known_hosts"

--- a/git_trac/app.py
+++ b/git_trac/app.py
@@ -507,7 +507,7 @@ class Application(object):
         Add the "trac" remotes (RW+RO) if necessary
         """
         REPO_RW = 'git@trac.sagemath.org:sage.git'
-        REPO_RO = 'git://trac.sagemath.org/sage.git'
+        REPO_RO = 'https://trac.sagemath.org/sage.git'
         remotes = self.git.remote().split()
         if 'trac' in remotes:
             cmd = 'set-url'

--- a/git_trac/app.py
+++ b/git_trac/app.py
@@ -507,7 +507,7 @@ class Application(object):
         Add the "trac" remotes (RW+RO) if necessary
         """
         REPO_RW = 'git@trac.sagemath.org:sage.git'
-        REPO_RO = 'https://trac.sagemath.org/sage.git'
+        REPO_RO = 'git@trac.sagemath.org:sage.git'
         remotes = self.git.remote().split()
         if 'trac' in remotes:
             cmd = 'set-url'


### PR DESCRIPTION
From the [documentation of git pull](https://git-scm.com/docs/git-pull):
> The native transport (i.e. git:// URL) does no authentication and should be used with caution on unsecured networks.

That's why I replaced the insecure git:// protocol with secure versions.
See also https://trac.sagemath.org/ticket/30736 for the second part of this pull request.