### PR TITLE
ReleaseApplication.merge: Actually handle merge conflicts

### DIFF
--- a/git_trac/releasemgr/app.py
+++ b/git_trac/releasemgr/app.py
@@ -15,7 +15,7 @@ from ..app import Application
 
 from ..people import RELEASE_MANAGER
 from git_trac.logger import logger as log
-
+from git_trac.git_error import GitError
 from git_trac.releasemgr.version_string import VersionString
 from git_trac.releasemgr.bootstrap import run_bootstrap
 from git_trac.releasemgr.fileserver_sagemath_org import \
@@ -131,7 +131,11 @@ class ReleaseApplication(Application):
         self.git.echo.fetch('trac', branch)
 
         print('Merging ticket...')
-        self.git.echo.merge('FETCH_HEAD', '--no-ff', '--no-commit')
+        try:
+            self.git.echo.merge('FETCH_HEAD', '--no-ff', '--no-commit')
+        except GitError:
+            # Merge conflicts are recognized below
+            pass
 
         status = self.git.status()
         if 'nothing to commit' in status:


### PR DESCRIPTION
Before:
```
Loading ticket...
URL: https://trac.sagemath.org/33100
Trac #33100: is_positive_definite returns wrong results
Branch u/mjo/ticket/33100
Author(s): Michael Orlitzky
Reviewer(s): Markus Wageringel
Fetching remote branch...

From git://trac.sagemath.org/sage
 * branch                  u/mjo/ticket/33100 -> FETCH_HEAD

Merging ticket...
Traceback (most recent call last):
  File "/Users/mkoeppe/s/sage/git-trac-command/git-releasemgr", line 16, in <module>
    cmdline.launch()
  File "/Users/mkoeppe/s/sage/git-trac-command/git_trac/releasemgr/cmdline.py", line 167, in launch
    app.merge_all(args.limit, milestone=args.milestone)
  File "/Users/mkoeppe/s/sage/git-trac-command/git_trac/releasemgr/app.py", line 283, in merge_all
    self.merge(ticket_number)
  File "/Users/mkoeppe/s/sage/git-trac-command/git_trac/releasemgr/app.py", line 134, in merge
    self.git.echo.merge('FETCH_HEAD', '--no-ff', '--no-commit')
  File "/Users/mkoeppe/s/sage/git-trac-command/git_trac/git_interface.py", line 340, in meth
    return self.execute(git_cmd, *args, **kwds)
  File "/Users/mkoeppe/s/sage/git-trac-command/git_trac/git_interface.py", line 97, in execute
    popen_stderr=subprocess.PIPE)
  File "/Users/mkoeppe/s/sage/git-trac-command/git_trac/git_interface.py", line 262, in _run
    raise GitError(result)
git_trac.git_error.GitError: git returned with non-zero exit code (1) when executing "git merge FETCH_HEAD --no-ff --no-commit"
    STDOUT: Auto-merging src/sage/matrix/matrix_double_dense.pyx
    STDOUT: CONFLICT (content): Merge conflict in src/sage/matrix/matrix_double_dense.pyx
    STDOUT: Automatic merge failed; fix conflicts and then commit the result.
```


