### PR TITLE
git releasemgr {todo,merge-all}: Add options --patchbot-status and --status

### DIFF
--- a/git_trac/releasemgr/app.py
+++ b/git_trac/releasemgr/app.py
@@ -290,8 +290,11 @@ class ReleaseApplication(Application):
             return 'sage-' + milestone
         return milestone
 
-    def _get_ready_tickets(self, milestone=None, patchbot_statuses=None):
-        params = ['status=positive_review']
+    def _get_ready_tickets(self, milestone=None, statuses=None, patchbot_statuses=None):
+        if statuses is None:
+            statuses = ['positive_review']
+        params = ['status={}'.format(status)
+                  for status in statuses]
         milestone = self._normalize_milestone(milestone)
         if milestone:
             params.append('milestone={0}'.format(milestone))
@@ -308,12 +311,13 @@ class ReleaseApplication(Application):
                 for ticket_number in ticket_numbers
                 if patchbot_status(ticket_number) in patchbot_statuses]
 
-    def todo(self, milestone=None, patchbot_statuses=None):
+    def todo(self, milestone=None, statuses=None, patchbot_statuses=None):
         """
         Print a list of tickets that are ready to be merged
         """
         milestone = self._normalize_milestone(milestone)
-        tickets = self._get_ready_tickets(milestone=milestone, patchbot_statuses=patchbot_statuses)
+        tickets = self._get_ready_tickets(milestone=milestone,
+                                          statuses=statuses, patchbot_statuses=patchbot_statuses)
         if milestone:
             milestone_str = 'for milestone {} '.format(milestone)
         else:
@@ -344,12 +348,13 @@ class ReleaseApplication(Application):
         self.git.fetch('trac', 'develop')
         return self.git.log('--oneline', '--first-parent', 'FETCH_HEAD~..HEAD')
 
-    def merge_all(self, limit=0, milestone=None, patchbot_statuses=None):
+    def merge_all(self, limit=0, milestone=None, statuses=None, patchbot_statuses=None):
         """
         Merge all tickets that are ready
         """
         milestone = self._normalize_milestone(milestone)
-        tickets = self._get_ready_tickets(milestone=milestone, patchbot_statuses=patchbot_statuses)
+        tickets = self._get_ready_tickets(milestone=milestone, statuses=statuses,
+                                          patchbot_statuses=patchbot_statuses)
         if milestone:
             milestone_str = 'for milestone {} '.format(milestone)
         else:

--- a/git_trac/releasemgr/app.py
+++ b/git_trac/releasemgr/app.py
@@ -299,7 +299,9 @@ class ReleaseApplication(Application):
         print(u'The following tickets {}are ready to be merged'.format(milestone_str))
         for ticket_number in tickets:
             t = self.trac.load(ticket_number)
-            print(u'* {ticket.number} {ticket.title} ({ticket.author})'.format(ticket=t))
+            s = patchbot_status(ticket_number)
+            print(u'* {ticket.number} {ticket.title} ({ticket.author}) 🤖{patchbot_status}'.format(
+                ticket=t, patchbot_status=s))
         print(u'Merge tickets with:')
         print(u'git releasemgr merge {0}'.format(' '.join(map(str, tickets))))
 

--- a/git_trac/releasemgr/app.py
+++ b/git_trac/releasemgr/app.py
@@ -190,9 +190,33 @@ class ReleaseApplication(Application):
                 raise ValueError('merge was not clean')
             self._commit(commit_message)
 
-    def merge_multiple(self, ticket_numbers, **kwds):
-        for ticket_number in ticket_numbers:
-            self.merge(ticket_number, **kwds)
+    def merge_multiple(self, ticket_numbers, limit=0, **kwds):
+        successful = []
+        errors = []
+        try:
+            for ticket_number in ticket_numbers:
+                try:
+                    self.merge(ticket_number)
+                    successful.append(ticket_number)
+                except ValueError as err:
+                    errors.append((ticket_number, str(err)))
+                    if u'ticket dependencies' not in str(err) and u'already merged' not in str(err):
+                        comment = 'Merge failure on top of:\n\n{}\n\n{}'.format(
+                            self.describe().replace('\n', '\n\n'), err)
+                        self.set_ticket_to_needs_work(ticket_number, comment)
+                if limit and (len(successful) >= limit):
+                    break
+        finally:
+            print("\n### Summary ###\n")
+            if len(ticket_numbers) != 1:
+                if successful:
+                    print('Successfully merged: {0}'.format(', '.join(map(str, successful))))
+                for ticket_number, error_message in errors:
+                    t = self.trac.load(ticket_number)
+                    print(u'')
+                    print(u'* {ticket.number} {ticket.title} ({ticket.author})'.format(ticket=t))
+                    print(u'  URL: https://trac.sagemath.org/{ticket.number}'.format(ticket=t))
+                    print(u'  Error: ' + error_message)
 
     def close_ticket(self, commit, ticket):
         if ticket.commit != commit.sha1:
@@ -333,28 +357,7 @@ class ReleaseApplication(Application):
             print(u'No tickets {}are ready to be merged'.format(milestone_str))
             return
         print(u'Merging tickets {}'.format(milestone_str))
-        successful = []
-        errors = []
-        for ticket_number in tickets:
-            try:
-                self.merge(ticket_number)
-                successful.append(ticket_number)
-            except ValueError as err:
-                errors.append((ticket_number, str(err)))
-                if u'ticket dependencies' not in str(err) and u'already merged' not in str(err):
-                    comment = 'Merge failure on top of:\n\n{}\n\n{}'.format(
-                        self.describe().replace('\n', '\n\n'), err)
-                    self.set_ticket_to_needs_work(ticket_number, comment)
-            if limit and (len(successful) >= limit):
-                break
-        if successful:
-            print('Successfully merged: {0}'.format(', '.join(map(str, successful))))
-        for ticket_number, error_message in errors:
-            t = self.trac.load(ticket_number)
-            print(u'')
-            print(u'* {ticket.number} {ticket.title} ({ticket.author})'.format(ticket=t))
-            print(u'  URL: https://trac.sagemath.org/{ticket.number}'.format(ticket=t))
-            print(u'  Error: ' + error_message)
+        return self.merge_multiple(tickets, limit=limit)
 
     def upstream(self, url):
         """

--- a/git_trac/releasemgr/app.py
+++ b/git_trac/releasemgr/app.py
@@ -138,7 +138,8 @@ class ReleaseApplication(Application):
         print('Merging ticket...')
         try:
             self.git.echo.merge('FETCH_HEAD', '--no-ff', '--no-commit')
-        except GitError:
+        except GitError as err:
+            print(err)
             # Merge conflicts are recognized below
             pass
 

--- a/git_trac/releasemgr/app.py
+++ b/git_trac/releasemgr/app.py
@@ -209,15 +209,14 @@ class ReleaseApplication(Application):
                     break
         finally:
             print("\n### Summary ###\n")
-            if len(ticket_numbers) != 1:
-                if successful:
-                    print('Successfully merged: {0}'.format(', '.join(map(str, successful))))
-                for ticket_number, error_message in errors:
-                    t = self.trac.load(ticket_number)
-                    print(u'')
-                    print(u'* {ticket.number} {ticket.title} ({ticket.author})'.format(ticket=t))
-                    print(u'  URL: https://trac.sagemath.org/{ticket.number}'.format(ticket=t))
-                    print(u'  Error: ' + error_message)
+            if successful:
+                print('Successfully merged: {0}'.format(', '.join(map(str, successful))))
+            for ticket_number, error_message in errors:
+                t = self.trac.load(ticket_number)
+                print(u'')
+                print(u'* {ticket.number} {ticket.title} ({ticket.author})'.format(ticket=t))
+                print(u'  URL: https://trac.sagemath.org/{ticket.number}'.format(ticket=t))
+                print(u'  Error: ' + error_message)
 
     def close_ticket(self, commit, ticket):
         if ticket.commit != commit.sha1:

--- a/git_trac/releasemgr/app.py
+++ b/git_trac/releasemgr/app.py
@@ -122,10 +122,10 @@ class ReleaseApplication(Application):
 
         import string
         if not ignore_name:
-            if not all(author[0].strip() in string.ascii_uppercase
+            if not all(author and author[0].strip() in string.ascii_uppercase
                        for author in ticket.author.split(',')):
                 raise ValueError(u'author {0} does not look right'.format(repr(ticket.author)))
-            if not all(reviewer[0].strip() in string.ascii_uppercase
+            if not all(reviewer and reviewer[0].strip() in string.ascii_uppercase
                        for reviewer in ticket.reviewer.split(',')):
                 raise ValueError(u'reviewer {0} does not look right'.format(repr(ticket.reviewer)))
 

--- a/git_trac/releasemgr/cmdline.py
+++ b/git_trac/releasemgr/cmdline.py
@@ -94,6 +94,10 @@ def launch():
                           'use "current" for best guess of current milestone')
         parser.add_argument('--milestone', dest='milestone',
                             help=milestone_help, default=None)
+        status_help = ('Only tickets with this status '
+                       '(default: positive_review)')
+        parser.add_argument('--status', type=str, nargs='*',
+                            help=status_help)
         patchbot_status_help = ('Only tickets with this patchbot status '
                                 '(TestsPassed, TestsPassedOnRetry, PluginOnlyFailed, Pending, ...) '
                                 '(default: any status)')
@@ -105,7 +109,7 @@ def launch():
     parser_confball = subparsers.add_parser('confball', help='Create new confball')
 
     # git releasemgr test
-    parser_test = subparsers.add_parser('test', help='Test merge unreview ticket')
+    parser_test = subparsers.add_parser('test', help='Test merge unreviewed ticket')
     parser_test.add_argument('ticket', type=int, help='Ticket number')
 
     # git releasemgr unmerge
@@ -172,9 +176,9 @@ def launch():
     elif args.subcommand == 'publish':
         app.publish()
     elif args.subcommand == 'todo':
-        app.todo(milestone=args.milestone, patchbot_statuses=args.patchbot_status)
+        app.todo(milestone=args.milestone, statuses=args.status, patchbot_statuses=args.patchbot_status)
     elif args.subcommand == 'merge-all':
-        app.merge_all(args.limit, milestone=args.milestone, patchbot_statuses=args.patchbot_status)
+        app.merge_all(args.limit, milestone=args.milestone, statuses=args.status, patchbot_statuses=args.patchbot_status)
     elif args.subcommand == 'confball':
         app.confball()
     elif args.subcommand == 'upstream':

--- a/git_trac/releasemgr/cmdline.py
+++ b/git_trac/releasemgr/cmdline.py
@@ -87,12 +87,19 @@ def launch():
     parser_merge_all = subparsers.add_parser('merge-all', help='Merge all tickets that are ready')
     parser_merge_all.add_argument('--limit', dest='limit', type=int,
                                   help='Merge this many tickets', default=0)
-    milestone_help = ('Merge only tickets in this milestone '
-                      '(default: any milestone other than sage-duplicate/invalid/wontfix, '
-                      'sage-feature, sage-pending, sage-wishlist); '
-                      'use "current" for best guess of current milestone')
-    parser_merge_all.add_argument('--milestone', dest='milestone',
-                                  help=milestone_help, default=None)
+    def add_filter_args(parser):
+        milestone_help = ('Only tickets in this milestone '
+                          '(default: any milestone other than sage-duplicate/invalid/wontfix, '
+                          'sage-feature, sage-pending, sage-wishlist); '
+                          'use "current" for best guess of current milestone')
+        parser.add_argument('--milestone', dest='milestone',
+                            help=milestone_help, default=None)
+        patchbot_status_help = ('Only tickets with this patchbot status '
+                                '(TestsPassed, TestsPassedOnRetry, PluginOnlyFailed, Pending, ...) '
+                                '(default: any status)')
+        parser.add_argument('--patchbot-status', type=str, nargs='*',
+                            help=patchbot_status_help)
+    add_filter_args(parser_merge_all)
 
     # git releasemgr print
     parser_confball = subparsers.add_parser('confball', help='Create new confball')
@@ -114,8 +121,7 @@ def launch():
 
     # git releasemgr todo
     parser_todo = subparsers.add_parser('todo', help='Print list of tickets ready to merge')
-    parser_todo.add_argument('--milestone', dest='milestone',
-                             help=milestone_help, default=None)
+    add_filter_args(parser_todo)
 
     # git releasemgr upstream <url>
     parser_upstream = subparsers.add_parser('upstream', help='Upload upstream tarball')
@@ -166,9 +172,9 @@ def launch():
     elif args.subcommand == 'publish':
         app.publish()
     elif args.subcommand == 'todo':
-        app.todo(milestone=args.milestone)
+        app.todo(milestone=args.milestone, patchbot_statuses=args.patchbot_status)
     elif args.subcommand == 'merge-all':
-        app.merge_all(args.limit, milestone=args.milestone)
+        app.merge_all(args.limit, milestone=args.milestone, patchbot_statuses=args.patchbot_status)
     elif args.subcommand == 'confball':
         app.confball()
     elif args.subcommand == 'upstream':

--- a/git_trac/releasemgr/patchbot.py
+++ b/git_trac/releasemgr/patchbot.py
@@ -1,0 +1,8 @@
+import requests
+
+def patchbot_status(ticket_number):
+    # until https://github.com/sagemath/sage-patchbot/pull/150 is merged:
+    r = requests.get('https://patchbot.sagemath.org/ticket/{}/status.svg'.format(ticket_number))
+    if "0.0507-64.833-64.833 46.117-46.117" in r.text:
+        return "TestsPassed"
+    return "TestsFailed"

--- a/git_trac/releasemgr/patchbot.py
+++ b/git_trac/releasemgr/patchbot.py
@@ -1,8 +1,5 @@
 import requests
 
 def patchbot_status(ticket_number):
-    # until https://github.com/sagemath/sage-patchbot/pull/150 is merged:
-    r = requests.get('https://patchbot.sagemath.org/ticket/{}/status.svg'.format(ticket_number))
-    if "0.0507-64.833-64.833 46.117-46.117" in r.text:
-        return "TestsPassed"
-    return "TestsFailed"
+    r = requests.get('https://patchbot.sagemath.org/ticket/{}/status'.format(ticket_number))
+    return r.text

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [options.extras_require]
-releasemgr = fabric
+releasemgr =
+    fabric
+    requests


### PR DESCRIPTION
`git releasemgr todo` now additionally shows patchbot status for each ticket.

The new option `--patchbot-status` allows filtering by patchbot statuses.

Use `git releasemgr merge-all --milestone current --patchbot-status TestsPassed PluginFailed TestsPassedOnRetry` for frustration-free merging fun.

The new option `--status` allows filtering by ticket statuses other than only `positive_review`. 

Use `git releasemgr merge-all --milestone current --patchbot-status Spkg ----status positive_review needs_review` to (test) merge all tickets that the patchbot won't test because of package upgrades. They will have to be run on GH Actions. This is for https://trac.sagemath.org/ticket/33222
