### PR TITLE
git releasemgr: Add option --trac-context

### DIFF
--- a/git_trac/releasemgr/app.py
+++ b/git_trac/releasemgr/app.py
@@ -26,6 +26,10 @@ from git_trac.releasemgr.sagepad_org import \
 
 class ReleaseApplication(Application):
 
+    def __init__(self, trac_context=''):
+        Application.__init__(self)
+        self._trac_context = trac_context
+
     def print_ticket(self, ticket_number):
         """
         INPUT:
@@ -193,7 +197,7 @@ class ReleaseApplication(Application):
         if ticket.commit != commit.sha1:
             raise RuntimeError('ticket #{0} branch changed (merged={1}, current={2})'
                                .format(ticket.number, commit.sha1, ticket.commit))
-        comment = ''
+        comment = self._trac_context
         attributes = {
             '_ts': ticket.timestamp,
             'status': 'closed',
@@ -294,6 +298,8 @@ class ReleaseApplication(Application):
         print(u'git releasemgr merge {0}'.format(' '.join(map(str, tickets))))
 
     def set_ticket_to_needs_work(self, ticket_number, comment):
+        if self._trac_context:
+            comment += '\n\n' + self._trac_context
         attributes = {
             'status': 'needs_work',
         }

--- a/git_trac/releasemgr/cmdline.py
+++ b/git_trac/releasemgr/cmdline.py
@@ -59,6 +59,9 @@ def launch():
                         help='debug')
     parser.add_argument('--log', dest='log', default=None,
                         help='one of [DEBUG, INFO, ERROR, WARNING, CRITICAL]')
+    parser.add_argument('--trac-context', dest='trac_context', type=str, default='',
+                        help='Text to add to comments on Trac tickets')
+
     subparsers = parser.add_subparsers(dest='subcommand')
 
     # git releasemgr print
@@ -143,7 +146,7 @@ def launch():
         return parser.print_help()
 
     from .app import ReleaseApplication
-    app = ReleaseApplication()
+    app = ReleaseApplication(trac_context=args.trac_context)
 
     if args.debug:
         debug_shell(app)


### PR DESCRIPTION
This allows to add some arbitrary text to the Trac ticket comments. 

Used in https://trac.sagemath.org/ticket/33222 to provide a link back to the GH Actions run.

(cherry-picked from the branch of #58)